### PR TITLE
Astrojarred/issue15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,236 @@
 npm
 
 *.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+*.lcov
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi/*
+!.pixi/config.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule*
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+# Temporary file for partial code execution
+tempCodeRunnerFile.py
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+# Deno
+# https://deno.com/
+
+# Cache directory (when using project-local DENO_DIR)
+# https://docs.deno.com/runtime/fundamentals/setup/#deno_dir
+.deno/
+
+# Coverage reports
+# https://docs.deno.com/runtime/reference/cli/coverage/
+coverage/
+*.lcov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+## Learned User Preferences
+
+- Prefer short one-line comments that explain purpose, not step-by-step operations.
+- Prefer fine-grained, human-style commits over large single AI-generated commits.
+- Remove AI-generated comments and replace with personal ones before committing.
+- Prefer PR descriptions as clear ELI5-style bullet points; avoid AI-sounding prose.
+
+## Learned Workspace Facts
+
+- sveltekit-python-vercel is a Deno project; build the npm package with `deno task dnt` or `deno run -A dnt.ts <version>` (output in `npm/`, gitignored). `deno task build` does not pass a version to dnt.ts.
+- Link consumer projects to the built package with `link:../sveltekit-python-vercel/npm` for local dev only — commit `^x.y.z` or `@beta` in deploy repos for Vercel.
+- npm publishes only from `.github/workflows/publish.yml` (npm trusted publishing allows one workflow per package): `beta` on main push, `pr-<n>` on same-repo PRs, `latest` on GitHub Release.
+- After rebuilding the linked package, restart the Vite dev server; reinstall in the consumer is usually not needed.
+- Local dev requires the sveltekit-python-vercel Vite plugin, which starts uvicorn on port 8000; proxy-only setups cause "fetch failed".
+- test-skpv-deploy is the test/deploy project for sveltekit-python-vercel.
+- test-skpv-deploy uses vendored `_python/build.py` for Vercel deploy (`vercel.json` buildCommand).
+- Pydantic: `field: type = default` works; prefer `Field(default=...)` for validation constraints; use `int` for params passed to numpy.
+- CI/publish requires Deno 2.x (`deno.lock` v5 needs 2.3+); use `denoland/setup-deno@v2` with `deno-version: v2.x`.
+- After dnt build, `dnt.ts` overwrites `npm/.npmignore` because dnt's default `src/` rule excludes needed `esm/src/` paths from the published tarball.
+- Python load files (`+page.server.py`, `+layout.server.py`): no user pip install; use return tuples (`("error", 404, "msg")`) or injected `error()`/`redirect()` helpers without imports.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,28 @@ Available on `event`: `params`, `url`, `route`, `parent` (layout data), `data` (
 
 **Current limitations:** no `event.fetch`, `setHeaders`, `depends`, or page options (`prerender`, etc.) in `.py` files yet.
 
+## npm channels
+
+| Tag | When it updates | Install |
+|-----|-----------------|---------|
+| `latest` | GitHub Release created | `pnpm add -D sveltekit-python-vercel` |
+| `beta` | Every push to `main` | `pnpm add -D sveltekit-python-vercel@beta` |
+| `pr-<n>` | Open/update PR `#n` (same-repo only) | `pnpm add -D sveltekit-python-vercel@pr-15` |
+
+Beta versions look like `1.0.3-beta.abc1234` (main) or `1.0.3-beta.pr15.abc1234` (PRs).
+
+All publishes run through `.github/workflows/publish.yml` because npm trusted publishing only allows one workflow filename per package.
+
+### Developing the package locally
+
+If you work on this repo and a consumer app side by side (e.g. `test-skpv-deploy`):
+
+1. Build: `deno run -A dnt.ts $(npm view sveltekit-python-vercel version)` (or any version string)
+2. In the consumer: `pnpm add -D sveltekit-python-vercel@link:../sveltekit-python-vercel/npm`
+3. Rebuild and restart the consumer dev server after library changes
+
+Commit `^x.y.z` or `@beta` in the consumer for Vercel — `link:` only works on your machine.
+
 ## Fork of `sveltekit-modal`
 
 Check out the awesome [sveltekit-modal](https://github.com/semicognitive/sveltekit-modal) package by [@semicognitive](https://github.com/semicognitive), the original way to get your python code running in SvelteKit. Modal even has GPU support for running an entire ML stack within SvelteKit.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Write Python endpoints in [SvelteKit](https://kit.svelte.dev/) and seamlessly de
 ## Current Features
 
 - Write `+server.py` files nearly the same way you would write `+server.js` files
+- Write server `load` functions in `+page.server.py` and `+layout.server.py`
 - Deploy automatically to Vercel Serverless (Python 3.12 runtime)
 
 ## Installing
@@ -153,6 +154,37 @@ Just push to your repository — no extra steps required.
 - `GET` endpoints receive query parameters directly as function arguments. Type annotations are used for coercion (e.g. `a: float` parses `?a=3` as `3.0`).
 - All other HTTP methods receive the request body as JSON. The recommended pattern is a Pydantic model as the single argument — FastAPI handles validation and parsing automatically.
 
+### Python load functions
+
+Server-side `load` functions work in `+page.server.py` and `+layout.server.py`. No extra Python package install is required — the runtime is bundled automatically like `+server.py`.
+
+```python
+async def load(event):
+    if event.params["id"] == "secret":
+        return ("redirect", 307, "/demo/public")
+
+    if event.params["id"] not in ("public", "1", "2"):
+        return ("error", 404, "Not found")
+
+    return {
+        "title": f"Item {event.params['id']}",
+        "parent_theme": event.parent.theme if event.parent else None,
+    }
+```
+
+Errors and redirects can also use injected helpers (no import needed):
+
+```python
+async def load(event):
+    if not event.cookies.get("session"):
+        redirect(307, "/login")
+    return {"ok": True}
+```
+
+Available on `event`: `params`, `url`, `route`, `parent` (layout data), `data` (from a sibling universal load), `cookies`.
+
+**Current limitations:** no `event.fetch`, `setHeaders`, `depends`, or page options (`prerender`, etc.) in `.py` files yet.
+
 ## Fork of `sveltekit-modal`
 
 Check out the awesome [sveltekit-modal](https://github.com/semicognitive/sveltekit-modal) package by [@semicognitive](https://github.com/semicognitive), the original way to get your python code running in SvelteKit. Modal even has GPU support for running an entire ML stack within SvelteKit.
@@ -163,5 +195,5 @@ Check out the awesome [sveltekit-modal](https://github.com/semicognitive/sveltek
 - [X] Generate endpoints automatically during build (via Vercel Build Output API)
   - [X] Auto-bundle requirements.txt / pyproject.toml / Pipfile at build time
 - [ ] Add form actions
-- [ ] Add load functions
+- [X] Add load functions
 - [ ] Add helper functions to automatically call API endpoints in project

--- a/src/vite/mod.ts
+++ b/src/vite/mod.ts
@@ -17,7 +17,7 @@ const get_pyServerEndpointAsString = (app_url: URL, serve = false) => `
         let fullURL;
 
         if (${serve}) {
-          fullURL = new URL(url.pathname, new URL('${app_url}')) + url.search;
+          fullURL = new URL('/api' + url.pathname, new URL('${app_url}')) + url.search;
         } else {
           fullURL = new URL('/api' + url.pathname, url.origin) + url.search;
         }

--- a/src/vite/mod.ts
+++ b/src/vite/mod.ts
@@ -40,6 +40,84 @@ const get_pyServerEndpointAsString = (app_url: URL, serve = false) => `
     export const DELETE = handle('DELETE');
 `;
 
+function getLoadRouteTemplate(id: string): string {
+  const marker = "/src/routes/";
+  const idx = id.indexOf(marker);
+  if (idx === -1) {
+    throw new Error(`Cannot derive load route from ${id}`);
+  }
+
+  let routePart = id.slice(idx + marker.length);
+  routePart = routePart.replace(/\/\+(?:page|layout)\.server\.py$/, "");
+
+  if (!routePart) {
+    return "/api/_load";
+  }
+
+  const segments = routePart
+    .split("/")
+    .filter((part) => !(part.startsWith("(") && part.endsWith(")")))
+    .map((part) => part.replace(/^\[(.+)\]$/, "{$1}"));
+
+  return `/api/_load/${segments.join("/")}`;
+}
+
+const get_pyLoadAsString = (
+  loadRouteTemplate: string,
+  app_url: URL,
+  serve = false
+) => `
+    import { error, redirect } from '@sveltejs/kit';
+
+    const LOAD_ROUTE_TEMPLATE = ${JSON.stringify(loadRouteTemplate)};
+
+    function buildLoadPath(params) {
+        let path = LOAD_ROUTE_TEMPLATE;
+        for (const [key, value] of Object.entries(params)) {
+            path = path.replaceAll(\`{\${key}}\`, encodeURIComponent(String(value)));
+        }
+        return path;
+    }
+
+    export async function load(event) {
+        const parent = event.parent ? await event.parent() : undefined;
+
+        const body = JSON.stringify({
+            params: event.params,
+            route: { id: event.route.id },
+            url: event.url.href,
+            parent,
+            data: event.data ?? undefined,
+            cookies: Object.fromEntries(event.cookies.getAll().map((c) => [c.name, c.value])),
+        });
+
+        const apiPath = buildLoadPath(event.params);
+        const fullURL = ${serve}
+            ? new URL(apiPath, new URL('${app_url}'))
+            : new URL(apiPath, event.url.origin);
+
+        const res = await event.fetch(fullURL, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body,
+        });
+
+        const result = await res.json();
+
+        if (result.type === 'redirect') redirect(result.status, result.location);
+        if (result.type === 'error') error(result.status, result.body);
+        return result.data;
+    }
+`;
+
+function isPyServerFile(id: string): boolean {
+  return /\+server\.py$/.test(id);
+}
+
+function isPyLoadFile(id: string): boolean {
+  return /\+(?:page|layout)\.server\.py$/.test(id);
+}
+
 export interface SveltekitPythonOptions {
   python_path?: string;
   log?: boolean;
@@ -74,8 +152,6 @@ export async function sveltekit_python_vercel(
         "esm/src/vite"
       );
 
-      // copy asll +server.py files to package directory
-
       run$.verbose = false;
       run$.env.PYTHONDONTWRITEBYTECODE = "1";
 
@@ -91,11 +167,10 @@ export async function sveltekit_python_vercel(
 
       cd$(config.root);
 
-      // local_process.quiet();  // let it be loud for now
       local_process.nothrow();
 
       local_process.stderr.on("data", (s) => {
-        console.log(s.toString().trimEnd()); //Logs stderr always and all of stdout if 'log': True
+        console.log(s.toString().trimEnd());
       });
       local_process.stderr.on("error", (s) => {
         console.error(chalk.red("Error: Python Serve Failed"));
@@ -117,22 +192,41 @@ export async function sveltekit_python_vercel(
     },
   };
 
+  const transformPyFile = (
+    id: string,
+    serve: boolean,
+    app_url: URL
+  ): {code: string; map: null} | undefined => {
+    if (!/\.py$/.test(id)) return undefined;
+
+    if (isPyServerFile(id)) {
+      return {
+        code: get_pyServerEndpointAsString(app_url, serve),
+        map: null,
+      };
+    }
+
+    if (isPyLoadFile(id)) {
+      const loadRouteTemplate = getLoadRouteTemplate(id);
+      return {
+        code: get_pyLoadAsString(loadRouteTemplate, app_url, serve),
+        map: null,
+      };
+    }
+
+    return undefined;
+  };
+
   const plugin_py_server_endpoint_serve: Plugin = {
     name: "vite-plugin-sveltekit_python-server-endpoint",
     apply: "serve",
     transform(src, id) {
-      // console.log("Transform function called for", id); // Add this line
-      if (/\.py$/.test(id)) {
-        if (sveltekit_url === undefined)
-          throw new Error(
-            `${plugin_python_serve.name} failed to produce a sveltekit_url`
-          );
-
-        return {
-          code: get_pyServerEndpointAsString(sveltekit_url, true),
-          map: null, // provide source map if available
-        };
+      if (sveltekit_url === undefined) {
+        throw new Error(
+          `${plugin_python_serve.name} failed to produce a sveltekit_url`
+        );
       }
+      return transformPyFile(id, true, sveltekit_url);
     },
   };
 
@@ -140,12 +234,7 @@ export async function sveltekit_python_vercel(
     name: "vite-plugin-sveltekit_python-server-endpoint",
     apply: "build",
     transform(src, id) {
-      if (/\.py$/.test(id)) {
-        return {
-          code: get_pyServerEndpointAsString(new URL("http://localhost"), false),
-          map: null,
-        };
-      }
+      return transformPyFile(id, false, new URL("http://localhost"));
     },
   };
 

--- a/src/vite/sveltekit_python_vercel/__init__.py
+++ b/src/vite/sveltekit_python_vercel/__init__.py
@@ -1,0 +1,3 @@
+from .load_runtime import error, redirect
+
+__all__ = ["error", "redirect"]

--- a/src/vite/sveltekit_python_vercel/build.py
+++ b/src/vite/sveltekit_python_vercel/build.py
@@ -23,7 +23,7 @@ func_dir.mkdir(parents=True, exist_ok=True)
 if args.packagedir:
     package_dir = Path(args.packagedir).absolute()
     shutil.copy(package_dir / "deploy.py", func_dir / "index.py")
-    for helper in ("load_runtime.py", "routes.py", "__init__.py"):
+    for helper in ("load_runtime.py", "routes.py"):
         src = package_dir / helper
         if src.exists():
             shutil.copy(src, func_dir / helper)
@@ -37,9 +37,6 @@ def _bundle_route_module(module_path: str, *, kind: str) -> None:
     target_dir = func_dir / route_parent(rel)
     target_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(abs_path, target_dir / rel.name)
-
-    if not (target_dir / "__init__.py").exists():
-        (target_dir / "__init__.py").touch()
 
     parent = route_parent(rel)
     if kind == "load":

--- a/src/vite/sveltekit_python_vercel/build.py
+++ b/src/vite/sveltekit_python_vercel/build.py
@@ -6,56 +6,61 @@ import subprocess
 import sys
 from pathlib import Path, PurePosixPath
 
+sys.path.insert(0, str(Path(__file__).parent))
+from routes import api_route, load_route, rel_path_from_routes, route_parent
+
 parser = argparse.ArgumentParser(description="Run SvelteKit Python Deployment")
 parser.add_argument("--root", default=".", help="Root directory of the SvelteKit project")
 parser.add_argument("--packagedir", default=None, help="Directory of the sveltekit-python-vercel package")
 args = parser.parse_args()
 
 root_dir = Path(args.root).absolute()
+routes_root = root_dir / "src/routes"
 
 func_dir = root_dir / ".vercel" / "output" / "functions" / "api" / "index.func"
 func_dir.mkdir(parents=True, exist_ok=True)
 
 if args.packagedir:
-    shutil.copy(Path(args.packagedir).absolute() / "deploy.py", func_dir / "index.py")
+    package_dir = Path(args.packagedir).absolute()
+    shutil.copy(package_dir / "deploy.py", func_dir / "index.py")
+    for helper in ("load_runtime.py", "routes.py", "__init__.py"):
+        src = package_dir / helper
+        if src.exists():
+            shutil.copy(src, func_dir / helper)
 
-# find all +server.py routes and copy them into the .func directory
 manifest = []
 
-for module_path in glob.glob(str(root_dir / "src/routes/**/+server.py"), recursive=True):
-    rel = Path(module_path).absolute().relative_to(root_dir / "src/routes")
 
-    # replace square brackets with curly brackets
-    rel = Path(str(rel).replace("[", "{").replace("]", "}"))
-
-    # remove any SvteleKit groups from the URL
-    parts = [
-        p for p in PurePosixPath(rel).parts
-        if not (p.startswith("(") and p.endswith(")"))
-    ]
-    rel = Path(*parts)
-
-    target_dir = func_dir / rel.parent
+def _bundle_route_module(module_path: str, *, kind: str) -> None:
+    abs_path = Path(module_path).absolute()
+    rel = rel_path_from_routes(abs_path, routes_root)
+    target_dir = func_dir / route_parent(rel)
     target_dir.mkdir(parents=True, exist_ok=True)
-
-    shutil.copy(module_path, target_dir / rel.name)
+    shutil.copy(abs_path, target_dir / rel.name)
 
     if not (target_dir / "__init__.py").exists():
         (target_dir / "__init__.py").touch()
 
-    # build the API route
-    parent = PurePosixPath(rel).parent
-    if str(parent) == ".":
-        api_route = "/api"
+    parent = route_parent(rel)
+    if kind == "load":
+        route = load_route(parent)
     else:
-        api_route = "/api/" + str(parent)
+        route = api_route(parent)
 
-    manifest.append({"file": str(PurePosixPath(rel)), "route": api_route})
-    print(f"PYTHON ENDPOINT: {module_path} → {api_route}")
+    entry = {"file": str(PurePosixPath(rel)), "route": route, "kind": kind}
+    manifest.append(entry)
+    print(f"PYTHON {'LOAD' if kind == 'load' else 'ENDPOINT'}: {module_path} → {route}")
+
+
+for module_path in glob.glob(str(routes_root / "**/+server.py"), recursive=True):
+    _bundle_route_module(module_path, kind="server")
+
+for pattern in ("**/+page.server.py", "**/+layout.server.py"):
+    for module_path in glob.glob(str(routes_root / pattern), recursive=True):
+        _bundle_route_module(module_path, kind="load")
 
 (func_dir / "_manifest.json").write_text(json.dumps(manifest, indent=2))
 
-# bundle the dependency file here
 dep_files = ["requirements.txt", "pyproject.toml", "uv.lock", "Pipfile", "Pipfile.lock"]
 found_dep = False
 for dep_file in dep_files:
@@ -69,7 +74,6 @@ if not found_dep:
     (func_dir / "requirements.txt").write_text("fastapi\nuvicorn\n")
     print("PYTHON ENDPOINT: No dependency file found, created minimal requirements.txt")
 
-# pre-install Python packages into _deps/ so they are available in the lambda env
 dep_dir = func_dir / "_deps"
 dep_dir.mkdir(exist_ok=True)
 pip_cmd = [sys.executable, "-m", "pip", "install", "--target", str(dep_dir), "--quiet"]
@@ -78,7 +82,6 @@ if (func_dir / "requirements.txt").exists():
     subprocess.run(pip_cmd, check=True)
     print("PYTHON ENDPOINT: Installed deps from requirements.txt")
 elif (func_dir / "pyproject.toml").exists():
-    # extract dependencies from pyproject.toml
     try:
         import tomllib
     except ImportError:
@@ -90,27 +93,21 @@ elif (func_dir / "pyproject.toml").exists():
         subprocess.run(pip_cmd + _deps_list, check=True)
         print(f"PYTHON ENDPOINT: Installed {len(_deps_list)} deps from pyproject.toml")
 
-# python3.12 is the AWS Lambda runtime string
 vc_config = {"runtime": "python3.12", "handler": "index.handler"}
 (func_dir / ".vc-config.json").write_text(json.dumps(vc_config, indent=2))
 print("PYTHON ENDPOINT: Created .vc-config.json")
 
-# patch the SvelteKit config.json that the endpoints are rerouted to python
 config_path = root_dir / ".vercel" / "output" / "config.json"
 if config_path.exists():
     config = json.loads(config_path.read_text())
     routes = config.get("routes", [])
-
     python_route = {"src": "^/api(/.*)?$", "dest": "api/index"}
-
-    # routes /api/* to python before SvelteKit catches it
     fs_idx = next(
         (i for i, r in enumerate(routes) if r.get("handle") == "filesystem"),
         0,
     )
     routes.insert(fs_idx, python_route)
     config["routes"] = routes
-
     config_path.write_text(json.dumps(config, indent=2))
     print("PYTHON ENDPOINT: Patched .vercel/output/config.json")
 else:

--- a/src/vite/sveltekit_python_vercel/deploy.py
+++ b/src/vite/sveltekit_python_vercel/deploy.py
@@ -16,6 +16,8 @@ if str(_base) not in sys.path:
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from load_runtime import run_load
+
 app = FastAPI()
 
 
@@ -26,11 +28,25 @@ def _load_module(file_path: Path):
     return mod
 
 
+def _make_load_handler(mod):
+    async def handler(request: Request):
+        payload = await request.json()
+        return JSONResponse(await run_load(mod, payload))
+
+    return handler
+
+
 _manifest_path = _base / "_manifest.json"
 if _manifest_path.exists():
     for _entry in json.loads(_manifest_path.read_text()):
         _mod = _load_module(_base / _entry["file"])
         _route = _entry["route"]
+        _kind = _entry.get("kind", "server")
+
+        if _kind == "load":
+            app.add_api_route(_route, _make_load_handler(_mod), methods=["POST"])
+            print(f"PYTHON LOAD: Registered POST {_route}")
+            continue
 
         for _method in ["GET", "POST", "PATCH", "PUT", "DELETE"]:
             _has_upper = hasattr(_mod, _method)
@@ -90,12 +106,10 @@ async def _dispatch(scope: dict, body: bytes) -> tuple[int, dict, bytes]:
 def handler(event, context):
     payload = json.loads(event.get("body") or "{}")
 
-    # parse the path and query string
     parsed = urlsplit(payload.get("path", "/"))
     path = parsed.path or "/"
     query = (parsed.query or "").encode()
 
-    # Build ASGI-style header list
     raw_headers: dict = payload.get("headers") or {}
     headers_list = []
     host = payload.get("host", "localhost")

--- a/src/vite/sveltekit_python_vercel/deploy.py
+++ b/src/vite/sveltekit_python_vercel/deploy.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from load_runtime import run_load
+from routes import route_registration_order
 
 app = FastAPI()
 
@@ -38,15 +39,19 @@ def _make_load_handler(mod):
 
 _manifest_path = _base / "_manifest.json"
 if _manifest_path.exists():
-    for _entry in json.loads(_manifest_path.read_text()):
+    _manifest = json.loads(_manifest_path.read_text())
+    _load_entries = [e for e in _manifest if e.get("kind") == "load"]
+    _server_entries = [e for e in _manifest if e.get("kind", "server") != "load"]
+
+    for _entry in sorted(_load_entries, key=lambda e: route_registration_order(e["route"])):
         _mod = _load_module(_base / _entry["file"])
         _route = _entry["route"]
-        _kind = _entry.get("kind", "server")
+        app.add_api_route(_route, _make_load_handler(_mod), methods=["POST"])
+        print(f"PYTHON LOAD: Registered POST {_route}")
 
-        if _kind == "load":
-            app.add_api_route(_route, _make_load_handler(_mod), methods=["POST"])
-            print(f"PYTHON LOAD: Registered POST {_route}")
-            continue
+    for _entry in _server_entries:
+        _mod = _load_module(_base / _entry["file"])
+        _route = _entry["route"]
 
         for _method in ["GET", "POST", "PATCH", "PUT", "DELETE"]:
             _has_upper = hasattr(_mod, _method)

--- a/src/vite/sveltekit_python_vercel/load_runtime.py
+++ b/src/vite/sveltekit_python_vercel/load_runtime.py
@@ -1,0 +1,91 @@
+import inspect
+import types
+from typing import Any, Optional
+
+
+class SKPVError(Exception):
+    def __init__(self, status: int, body: Any):
+        self.status = status
+        self.body = body
+        super().__init__(body)
+
+
+class SKPVRedirect(Exception):
+    def __init__(self, status: int, location: str):
+        self.status = status
+        self.location = location
+        super().__init__(location)
+
+
+def error(status: int, body: Any) -> None:
+    raise SKPVError(status, body)
+
+
+def redirect(status: int, location: str) -> None:
+    raise SKPVRedirect(status, location)
+
+
+def inject_load_helpers(mod) -> None:
+    if not hasattr(mod, "error"):
+        mod.error = error
+    if not hasattr(mod, "redirect"):
+        mod.redirect = redirect
+
+
+def _to_namespace(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        ns = types.SimpleNamespace()
+        for key, val in value.items():
+            setattr(ns, key, _to_namespace(val))
+        return ns
+    if isinstance(value, list):
+        return [_to_namespace(item) for item in value]
+    return value
+
+
+class _Cookies:
+    def __init__(self, data: Optional[dict]):
+        self._data = data or {}
+
+    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        return self._data.get(name, default)
+
+
+def wrap_event(payload: dict) -> types.SimpleNamespace:
+    event = types.SimpleNamespace()
+    event.params = payload.get("params") or {}
+    event.route = _to_namespace(payload.get("route") or {})
+    event.url = payload.get("url", "")
+    event.parent = _to_namespace(payload.get("parent"))
+    event.data = payload.get("data")
+    event.cookies = _Cookies(payload.get("cookies"))
+    return event
+
+
+def parse_load_result(result: Any) -> dict:
+    if (
+        isinstance(result, tuple)
+        and len(result) == 3
+        and result[0] in ("error", "redirect")
+    ):
+        kind, status, payload = result
+        if kind == "error":
+            return {"type": "error", "status": status, "body": payload}
+        return {"type": "redirect", "status": status, "location": payload}
+    return {"type": "data", "data": result}
+
+
+async def run_load(mod, payload: dict) -> dict:
+    inject_load_helpers(mod)
+    event = wrap_event(payload)
+    try:
+        result = mod.load(event)
+        if inspect.iscoroutine(result):
+            result = await result
+        return parse_load_result(result)
+    except SKPVRedirect as exc:
+        return {"type": "redirect", "status": exc.status, "location": exc.location}
+    except SKPVError as exc:
+        return {"type": "error", "status": exc.status, "body": exc.body}

--- a/src/vite/sveltekit_python_vercel/routes.py
+++ b/src/vite/sveltekit_python_vercel/routes.py
@@ -1,0 +1,34 @@
+from pathlib import Path, PurePosixPath
+
+
+def rel_path_from_routes(module_path: Path, routes_root: Path) -> PurePosixPath:
+    """Route file path relative to src/routes, with groups stripped and [param] → {param}."""
+    rel = module_path.absolute().relative_to(routes_root)
+    rel = Path(str(rel).replace("[", "{").replace("]", "}"))
+    parts = [
+        p
+        for p in PurePosixPath(rel).parts
+        if not (p.startswith("(") and p.endswith(")"))
+    ]
+    return PurePosixPath(*parts)
+
+
+def route_parent(rel: PurePosixPath) -> PurePosixPath:
+    return PurePosixPath(rel).parent
+
+
+def api_route(rel_parent: PurePosixPath, *, prefix: str = "/api") -> str:
+    if str(rel_parent) == ".":
+        return prefix
+    return f"{prefix}/{rel_parent}"
+
+
+def load_route(rel_parent: PurePosixPath) -> str:
+    return api_route(rel_parent, prefix="/api/_load")
+
+
+def resolve_route_path(template: str, params: dict) -> str:
+    path = template
+    for key, value in params.items():
+        path = path.replace(f"{{{key}}}", str(value))
+    return path

--- a/src/vite/sveltekit_python_vercel/routes.py
+++ b/src/vite/sveltekit_python_vercel/routes.py
@@ -32,3 +32,8 @@ def resolve_route_path(template: str, params: dict) -> str:
     for key, value in params.items():
         path = path.replace(f"{{{key}}}", str(value))
     return path
+
+
+def route_registration_order(route: str) -> tuple:
+    """Static routes before dynamic; longer paths before shorter."""
+    return ("{" in route, -len(route), route)

--- a/src/vite/sveltekit_python_vercel/serve.py
+++ b/src/vite/sveltekit_python_vercel/serve.py
@@ -1,12 +1,17 @@
 import argparse
 import glob
-import importlib
 import importlib.util
 import shutil
-from pathlib import Path, PurePosixPath
+import sys
+from pathlib import Path
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+sys.path.insert(0, str(Path(__file__).parent))
+from load_runtime import run_load
+from routes import api_route, load_route, rel_path_from_routes, route_parent
 
 parser = argparse.ArgumentParser(description="Run Sveltekit Python Server")
 parser.add_argument("--host", default="0.0.0.0", help="Server hostname")
@@ -17,57 +22,68 @@ args = parser.parse_args()
 app = FastAPI()
 
 root_dir = Path(args.root).absolute()
-
 api_dir = Path("./sveltekit_python_vercel").absolute()
+routes_root = root_dir / "src/routes"
+watch_modules = []
 
-route_dir = root_dir.joinpath("src/routes")
 
-watch_modules = []  # list of modules to watch for changes
+def _copy_module(module_path: Path) -> Path:
+    api_route_path = api_dir.joinpath(module_path.relative_to(routes_root))
+    api_route_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(module_path, api_route_path.parent / api_route_path.name)
+    return api_route_path.parent / api_route_path.name
 
-for module_path in glob.glob(
-    route_dir.joinpath("**/+server.py").as_posix(), recursive=True
-):
-    abs_module_path = Path(module_path).absolute()
 
-    watch_modules.append(abs_module_path.parent.as_posix())
-
-    api_route = api_dir.joinpath(abs_module_path.relative_to(root_dir / "src/routes"))
-
-    if not api_route.parent.exists():
-        api_route.parent.mkdir(parents=True)
-
-    # copy module path to api_route
-    shutil.copy(module_path, api_route.parent)
-
-    module_name = api_route.stem
-
-    spec = importlib.util.spec_from_file_location(module_name, api_route)
+def _load_module(api_route_path: Path):
+    spec = importlib.util.spec_from_file_location(api_route_path.stem, api_route_path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
+    return mod
 
-    # Get the relative path of the module from the API directory
-    rel_path = api_route.relative_to(api_dir)
 
-    # Convert the relative path to a string and remove the file extension
-    api_path = f"/{rel_path.parent}"
+def _make_load_handler(mod):
+    async def handler(request: Request):
+        payload = await request.json()
+        return JSONResponse(await run_load(mod, payload))
 
-    # Replace square brackets with curly brackets
-    api_path = api_path.replace("[", "{").replace("]", "}")
-    
-    # remove any groups from the URL
-    api_path = str(PurePosixPath(*[part for part in PurePosixPath(api_path).parts if not part.startswith("(") and not part.endswith(")")]))
+    return handler
 
-    # Add endpoints
+
+for module_path in glob.glob(routes_root.joinpath("**/+server.py").as_posix(), recursive=True):
+    abs_module_path = Path(module_path).absolute()
+    watch_modules.append(abs_module_path.parent.as_posix())
+
+    api_route_path = _copy_module(abs_module_path)
+    mod = _load_module(api_route_path)
+
+    rel = rel_path_from_routes(abs_module_path, routes_root)
+    api_path = api_route(rel.parent)
+
     for method in ["GET", "POST", "PATCH", "PUT", "DELETE"]:
-        # Check for duplicate methods
         if hasattr(mod, method) and hasattr(mod, method.lower()):
             raise Exception(
-                f"Duplicate method {method} and {method.lower()} in {api_route}"
+                f"Duplicate method {method} and {method.lower()} in {api_route_path}"
             )
         elif hasattr(mod, method):
             app.add_api_route(api_path, getattr(mod, method), methods=[method])
         elif hasattr(mod, method.lower()):
             app.add_api_route(api_path, getattr(mod, method.lower()), methods=[method])
+
+for pattern in ("**/+page.server.py", "**/+layout.server.py"):
+    for module_path in glob.glob(routes_root.joinpath(pattern).as_posix(), recursive=True):
+        abs_module_path = Path(module_path).absolute()
+        watch_modules.append(abs_module_path.parent.as_posix())
+
+        api_route_path = _copy_module(abs_module_path)
+        mod = _load_module(api_route_path)
+
+        if not hasattr(mod, "load"):
+            raise Exception(f"Missing load function in {abs_module_path}")
+
+        rel = rel_path_from_routes(abs_module_path, routes_root)
+        load_path = load_route(route_parent(rel))
+        app.add_api_route(load_path, _make_load_handler(mod), methods=["POST"])
+        print(f"PYTHON LOAD: Registered POST {load_path} ← {abs_module_path}")
 
 
 if __name__ == "__main__":

--- a/src/vite/sveltekit_python_vercel/serve.py
+++ b/src/vite/sveltekit_python_vercel/serve.py
@@ -11,7 +11,13 @@ from fastapi.responses import JSONResponse
 
 sys.path.insert(0, str(Path(__file__).parent))
 from load_runtime import run_load
-from routes import api_route, load_route, rel_path_from_routes, route_parent
+from routes import (
+    api_route,
+    load_route,
+    rel_path_from_routes,
+    route_parent,
+    route_registration_order,
+)
 
 parser = argparse.ArgumentParser(description="Run Sveltekit Python Server")
 parser.add_argument("--host", default="0.0.0.0", help="Server hostname")
@@ -69,6 +75,7 @@ for module_path in glob.glob(routes_root.joinpath("**/+server.py").as_posix(), r
         elif hasattr(mod, method.lower()):
             app.add_api_route(api_path, getattr(mod, method.lower()), methods=[method])
 
+load_entries = []
 for pattern in ("**/+page.server.py", "**/+layout.server.py"):
     for module_path in glob.glob(routes_root.joinpath(pattern).as_posix(), recursive=True):
         abs_module_path = Path(module_path).absolute()
@@ -82,8 +89,13 @@ for pattern in ("**/+page.server.py", "**/+layout.server.py"):
 
         rel = rel_path_from_routes(abs_module_path, routes_root)
         load_path = load_route(route_parent(rel))
-        app.add_api_route(load_path, _make_load_handler(mod), methods=["POST"])
-        print(f"PYTHON LOAD: Registered POST {load_path} ← {abs_module_path}")
+        load_entries.append((load_path, mod, abs_module_path))
+
+for load_path, mod, abs_module_path in sorted(
+    load_entries, key=lambda entry: route_registration_order(entry[0])
+):
+    app.add_api_route(load_path, _make_load_handler(mod), methods=["POST"])
+    print(f"PYTHON LOAD: Registered POST {load_path} ← {abs_module_path}")
 
 
 if __name__ == "__main__":

--- a/src/vite/sveltekit_python_vercel/test_load_runtime.py
+++ b/src/vite/sveltekit_python_vercel/test_load_runtime.py
@@ -1,0 +1,119 @@
+import types
+import unittest
+
+from load_runtime import (
+    SKPVError,
+    inject_load_helpers,
+    parse_load_result,
+    redirect,
+    run_load,
+    wrap_event,
+)
+
+
+class ParseLoadResultTests(unittest.TestCase):
+    def test_data(self):
+        self.assertEqual(
+            parse_load_result({"ok": True}),
+            {"type": "data", "data": {"ok": True}},
+        )
+
+    def test_error_tuple(self):
+        self.assertEqual(
+            parse_load_result(("error", 404, "Not found")),
+            {"type": "error", "status": 404, "body": "Not found"},
+        )
+
+    def test_redirect_tuple(self):
+        self.assertEqual(
+            parse_load_result(("redirect", 307, "/login")),
+            {"type": "redirect", "status": 307, "location": "/login"},
+        )
+
+    def test_tuple_data_not_misread(self):
+        self.assertEqual(
+            parse_load_result(("items", 1, 2)),
+            {"type": "data", "data": ("items", 1, 2)},
+        )
+
+
+class RunLoadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_injected_error(self):
+        mod = types.ModuleType("test")
+        exec(
+            compile(
+                "async def load(event):\n    error(403, 'denied')\n",
+                "<test>",
+                "exec",
+            ),
+            mod.__dict__,
+        )
+        result = await run_load(mod, {"params": {}})
+        self.assertEqual(result["type"], "error")
+        self.assertEqual(result["status"], 403)
+
+    async def test_injected_redirect(self):
+        mod = types.ModuleType("test")
+        exec(
+            compile(
+                "async def load(event):\n    redirect(307, '/home')\n",
+                "<test>",
+                "exec",
+            ),
+            mod.__dict__,
+        )
+        result = await run_load(mod, {"params": {}})
+        self.assertEqual(result["type"], "redirect")
+        self.assertEqual(result["location"], "/home")
+
+    async def test_return_tuple_error(self):
+        mod = types.ModuleType("test")
+
+        async def load(event):
+            return ("error", 404, "missing")
+
+        mod.load = load
+        result = await run_load(mod, {"params": {}})
+        self.assertEqual(result, {"type": "error", "status": 404, "body": "missing"})
+
+    async def test_wrap_event_parent_and_cookies(self):
+        mod = types.ModuleType("test")
+        captured = {}
+
+        async def load(event):
+            captured["theme"] = event.parent.theme
+            captured["session"] = event.cookies.get("session")
+            return {"ok": True}
+
+        mod.load = load
+        await run_load(
+            mod,
+            {
+                "params": {"id": "1"},
+                "parent": {"theme": "dark"},
+                "cookies": {"session": "abc"},
+            },
+        )
+        self.assertEqual(captured["theme"], "dark")
+        self.assertEqual(captured["session"], "abc")
+
+    async def test_user_error_helper_not_overwritten(self):
+        mod = types.ModuleType("test")
+
+        def custom_error(status, body):
+            raise SKPVError(418, "teapot")
+
+        mod.error = custom_error
+
+        async def load(event):
+            custom_error(404, "ignored")
+
+        mod.load = load
+        inject_load_helpers(mod)
+        with self.assertRaises(SKPVError) as ctx:
+            await mod.load(wrap_event({}))
+        self.assertEqual(ctx.exception.status, 418)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #15. 

We can now write SvelteKit server load functions in Python (`+page.server.py` and `+layout.server.py`)

- SvelteKit still runs load on the Node side, but the .py file gets turned into a thin JS shim that POSTs to a Python endpoint (/api/_load/...)
- No extra Python package for users to install — the runtime ships with the plugin and gets copied into the function bundle at build time.

Included: 
- Return normal page/layout data from async def load(event)
- Use event.params, event.url, event.route, event.parent, event.data, event.cookies
- errors: return ("error", 404, "Not found")
- redirects: return ("redirect", 307, "/somewhere")
Or call error(...) / redirect(...) with no import — they get injected when your module runs

